### PR TITLE
Also explicitly require 'auto-complete

### DIFF
--- a/ac-slime.el
+++ b/ac-slime.el
@@ -15,6 +15,7 @@
 
 (eval-when-compile (require 'cl))
 (require 'slime)
+(require 'auto-complete)
 
 (defun ac-source-slime-fuzzy-candidates ()
   "Return a possibly-empty list of fuzzy completions for the symbol at point."


### PR DESCRIPTION
Without this, the autoloads of `set-up-slime-ac` are kind of useless. They autoload `ac-slime.el` but they don't ensure `auto-complete` is loaded afterwards, hence `slime-connect` eventualy fails in a reference to the unbound `ac-sources`, unless the user has already `require`d it.

Make sense?
