### PR TITLE
I did this a long time ago, please check it out. sorry if I messed up the code but I think its worth checking.

### DIFF
--- a/ac-slime.el
+++ b/ac-slime.el
@@ -22,8 +22,9 @@
 (defvar ac-slime-current-doc nil "Holds slime docstring for current symbol")
 
 (defun ac-slime-documentation (symbol-info)
-  (let ((symbol (substring-no-properties symbol-info)))
-    (slime-eval `(swank:documentation-symbol ,symbol))))
+  (ignore-errors
+   (let ((symbol (substring-no-properties symbol-info)))
+     (slime-eval `(swank:documentation-symbol ,symbol)))))
 
 (defun ac-slime-init ()
   (setq ac-slime-current-doc nil))


### PR DESCRIPTION
For example instead of |defun              l| you can see the actual
flags of the symbols like: |defun       -f---m--| in the completion
menu.
