### PR TITLE
Workaround for newer slime

### DIFF
--- a/ac-slime.el
+++ b/ac-slime.el
@@ -63,7 +63,10 @@
 (defun ac-source-slime-simple-candidates ()
   "Return a possibly-empty list of completions for the symbol at point."
   (when (slime-connected-p)
-    (car (slime-simple-completions (substring-no-properties ac-prefix)))))
+    (let ((completions (slime-simple-completions (substring-no-properties ac-prefix))))
+      (if (listp (car completions))
+          (car completions)
+        completions))))
 
 (defun ac-source-slime-case-correcting-completions (name collection)
   (mapcar #'(lambda (completion)


### PR DESCRIPTION
Return value type of slime-simple-completions was changed(at https://github.com/slime/slime/commit/ff9bf80e2ce811cab6482cb7d0a857b754adf7fe).
Original is '((candidate1 candidate2 ...) prefix), newer version is '(candidate1 candidate2 ...).

I suppose that http://stackoverflow.com/questions/31708770/slime-ac-does-not-work-with-sbcl-1-2-13-and-slime-2-14-on-osx-10-9-5 is related to this issue.
